### PR TITLE
Fix the Keyboard Shortcuts in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,9 +105,9 @@ You can quickly open a command input box by registering the extension command to
 
 ```
   { "key": "ctrl+r ctrl+r", "command": "editWithShell.runCommand",
-                            "when": "editorTextFocus" },
-  { "key": "ctrl+r ctrl+1", "command": "editWithShell.quickCommand1",
-                            "when": "editorTextFocus" },
+                            "when": "editorTextFocus && !editorReadonly" },
+  { "key": "ctrl+r ctrl+1", "command": "editWithShell.runQuickCommand1",
+                            "when": "editorTextFocus && !editorReadonly" },
 ```
 
 ## Changelog


### PR DESCRIPTION
Fix the incorrect command in Kyboard Shortcuts section, and add a condition to prevent command to run when the editor is readonly since most people will use the command to edit document.